### PR TITLE
Removing duplicated gem entry (rspec-rails)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,17 +32,13 @@ gem 'bootsnap', '>= 1.4.2', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'rspec-rails', '~> 3.8'
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'rspec-rails', '~> 3.8'
-end
-
-group :test do
-  gem 'rspec-rails', '~> 3.8'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
With this PR, I am proposing a solution for the warning of the duplicated entry of `rspec-rails` gem. It should be preferentially be referenced only once, so when an update is necessary, we don't risk having different versions by forgetting to update all entries.

Since the gem is used in development and test group, we just move its entry to a region that refers to both groups.